### PR TITLE
Two bugfixes, improved err msg, and whitespace removal

### DIFF
--- a/gan_cifar.py
+++ b/gan_cifar.py
@@ -16,12 +16,18 @@ import tflib.cifar10
 import tflib.inception_score
 import tflib.plot
 
-# Download CIFAR-10 (Python version) at
-# https://www.cs.toronto.edu/~kriz/cifar.html and fill in the path to the
-# extracted files here!
 DATA_DIR = ''
 if len(DATA_DIR) == 0:
-    raise Exception('Please specify path to data directory in gan_cifar.py!')
+    raise Exception('''
+Please specify path to data directory in gan_cifar.py!
+
+Download CIFAR-10 (Python version) at
+https://www.cs.toronto.edu/~kriz/cifar.html and fill in the path to the
+extracted files.
+
+> wget https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
+> tar -xvzf cifar-10-python.tar.gz
+''')
 
 MODE = 'wgan-gp' # Valid options are dcgan, wgan, or wgan-gp
 DIM = 128 # This overfits substantially; you're probably better off with 64
@@ -110,7 +116,7 @@ if MODE == 'wgan':
         clip_bounds = [-.01, .01]
         clip_ops.append(
             tf.assign(
-                var, 
+                var,
                 tf.clip_by_value(var, clip_bounds[0], clip_bounds[1])
             )
         )
@@ -123,7 +129,7 @@ elif MODE == 'wgan-gp':
 
     # Gradient penalty
     alpha = tf.random_uniform(
-        shape=[BATCH_SIZE,1], 
+        shape=[BATCH_SIZE,1],
         minval=0.,
         maxval=1.
     )
@@ -207,7 +213,7 @@ with tf.Session() as session:
         if iteration % 100 == 99:
             dev_disc_costs = []
             for images,_ in dev_gen():
-                _dev_disc_cost = session.run(disc_cost, feed_dict={real_data_int: images}) 
+                _dev_disc_cost = session.run(disc_cost, feed_dict={real_data_int: images})
                 dev_disc_costs.append(_dev_disc_cost)
             lib.plot.plot('dev disc cost', np.mean(dev_disc_costs))
             generate_image(iteration, _data)

--- a/tflib/inception_score.py
+++ b/tflib/inception_score.py
@@ -20,7 +20,7 @@ MODEL_DIR = '/tmp/imagenet'
 DATA_URL = 'http://download.tensorflow.org/models/image/imagenet/inception-2015-12-05.tgz'
 softmax = None
 
-# Call this function with list of images. Each of elements should be a 
+# Call this function with list of images. Each of elements should be a
 # numpy array with values ranging from 0 to 255.
 def get_inception_score(images, splits=10):
   assert(type(images) == list)
@@ -88,9 +88,9 @@ def _init_inception():
                     new_shape.append(None)
                 else:
                     new_shape.append(s)
-            o._shape = tf.TensorShape(new_shape)
+            o.set_shape(tf.TensorShape(new_shape))
     w = sess.graph.get_operation_by_name("softmax/logits/MatMul").inputs[1]
-    logits = tf.matmul(tf.squeeze(pool3), w)
+    logits = tf.matmul(tf.squeeze(pool3, [1, 2]), w)
     softmax = tf.nn.softmax(logits)
 
 if softmax is None:

--- a/tflib/inception_score.py
+++ b/tflib/inception_score.py
@@ -32,7 +32,7 @@ def get_inception_score(images, splits=10):
   for img in images:
     img = img.astype(np.float32)
     inps.append(np.expand_dims(img, 0))
-  bs = 100
+  bs = 1
   with tf.Session() as sess:
     preds = []
     n_batches = int(math.ceil(float(len(inps)) / float(bs)))


### PR DESCRIPTION
Two bugfixes:
- set_shape instead of _shape
- don't squeeze away all singleton dimensions before matmul, leave batch dimension intact

Improved error message explaining how to download CIFAR-10

Whitespace removal (sorry, my editor does this automatically, and I assume you don't mind)